### PR TITLE
Remove grunt.util._ / Update dependencies

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -2,7 +2,7 @@
 # grunt-jinja
 # https://github.com/matthewwithanm/grunt-jinja
 #
-# Copyright (c) 2013 Matthew Tretter
+# Copyright (c) 2013 - 2014 Matthew Tretter
 # Licensed under the MIT license.
 #
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -6,10 +6,10 @@
 # Licensed under the MIT license.
 #
 
-path = require 'path'
-
-
 module.exports = (grunt) ->
+  'use strict'
+  
+  path = require 'path'
 
   # Project configuration.
   grunt.initConfig
@@ -22,13 +22,13 @@ module.exports = (grunt) ->
     jinja:
       simple:
         options:
-          templateDirs: [path.join __dirname, 'test/fixtures/simple/']
+          templateDirs: ['./test/fixtures/simple/']
         files:
           'tmp/simple/index.html': 'test/fixtures/simple/index.html'
       context:
         options:
-          templateDirs: [path.join __dirname, 'test/fixtures/context/templates/']
-          contextRoot: path.join __dirname, 'test/fixtures/context/template-context/'
+          templateDirs: ['./test/fixtures/context/templates/']
+          contextRoot: './test/fixtures/context/template-context/'
         files:
           'tmp/context/index.html': 'test/fixtures/context/templates/index.html'
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Matthew Tretter
+Copyright (c) 2013 - 2014 Matthew Tretter
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ A boolean which, if true, will escape all output by default See
 Type: `Object`
 Default value: {}
 
-An object specifying custom block start and end tags. See [Customizing Variable
-and Block Tags][3].
+An object specifying custom block start and end tags. See [Custom Tags][3].
 
 
 ### Usage Examples
@@ -144,7 +143,7 @@ grunt.initConfig({
 ```
 
 [nunjucks]: https://github.com/jlongster/nunjucks
-[1]: http://nunjucks.jlongster.com/api#Environment
-[2]: http://nunjucks.jlongster.com/api#Autoescaping
-[3]: http://nunjucks.jlongster.com/api#Customizing-Variable-and-Block-Tags
-[addFilter]: http://nunjucks.jlongster.com/api#Custom-Filters
+[1]: http://nunjucks.jlongster.com/api#environment
+[2]: http://nunjucks.jlongster.com/api#autoescaping
+[3]: http://jlongster.github.io/nunjucks/api.html#custom-tags
+[addFilter]: http://nunjucks.jlongster.com/api#custom-filters

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
       "url": "https://github.com/matthewwithanm/grunt-jinja/blob/master/LICENSE"
     }
   ],
+  "keywords": [
+    "gruntplugin"
+  ],
   "main": "Gruntfile.coffee",
   "engines": {
     "node": ">= 0.8.0"
@@ -27,18 +30,16 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "nunjucks": "~1.0.1",
+    "lodash": "~2.4.1"
+  },
   "devDependencies": {
-    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"
-  },
-  "keywords": [
-    "gruntplugin"
-  ],
-  "dependencies": {
-    "nunjucks": "~0.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
+    "grunt-contrib-nodeunit": "~0.3.0",
     "grunt": "~0.4.2"
   },
   "peerDependencies": {

--- a/tasks/jinja.coffee
+++ b/tasks/jinja.coffee
@@ -6,23 +6,22 @@
 # Licensed under the MIT license.
 #
 
-nunjucks = require 'nunjucks'
+'use strict'
+
 path = require 'path'
 
-
 module.exports = (grunt) ->
-  _ = grunt.util._
-
+  _ = require 'lodash'
+  nunjucks = require 'nunjucks'
 
   removeInvalidFiles = (files) ->
     files.src.filter (filepath) ->
       # Warn on and remove invalid source files (if nonull was set).
       unless grunt.file.exists filepath
-        grunt.log.warn """Source file "#{ filepath }" not found."""
+        grunt.log.warn "Source file \"#{ filepath }\" not found."
         false
       else
         true
-
 
   grunt.registerMultiTask 'jinja', 'A grunt plugin for compiling Jinja2 templates with nunjucks.', ->
     # Merge task-specific and/or target-specific options with these defaults.
@@ -66,7 +65,7 @@ module.exports = (grunt) ->
       validFiles = removeInvalidFiles f
 
       if validFiles.length > 1
-        grunt.fail.warn """Can't compile multiple sources into a single destination: #{ ', '.join validFiles }"""
+        grunt.fail.warn "Can't compile multiple sources into a single destination: #{ ', '.join validFiles }"
 
       validFiles.forEach (src) ->
         # Get the template name from the filepath
@@ -76,7 +75,7 @@ module.exports = (grunt) ->
             relPath = path.relative dir, fullPath
             unless relPath[0] is '.'
               return relPath
-          throw new Error """Couldn't find "#{ src }" in template dirs: #{ templateDirs.join ', ' }"""
+          throw new Error "Couldn't find \"#{ src }\" in template dirs: #{ templateDirs.join ', ' }"
 
         context = _.extend {}, loadContext('_all', false), loadContext(templateName)
         tmpl = env.getTemplate templateName
@@ -86,4 +85,4 @@ module.exports = (grunt) ->
           grunt.log.error err
           grunt.fail.warn "Couldn't render Jinja template."
         grunt.file.write f.dest, output
-        grunt.log.writeln """File "#{ f.dest }" created."""
+        grunt.log.writeln "File \"#{ f.dest }\" created."

--- a/tasks/jinja.coffee
+++ b/tasks/jinja.coffee
@@ -2,15 +2,15 @@
 # grunt-jinja
 # https://github.com/matthewwithanm/grunt-jinja
 #
-# Copyright (c) 2013 Matthew Tretter
+# Copyright (c) 2013 - 2014 Matthew Tretter
 # Licensed under the MIT license.
 #
 
 'use strict'
 
-path = require 'path'
-
 module.exports = (grunt) ->
+  path = require 'path'
+  
   _ = require 'lodash'
   nunjucks = require 'nunjucks'
 


### PR DESCRIPTION
- I replaced `grunt.util._` with [Lo-Dash on npm](https://npmjs.org/package/lodash), because `grunt.util._` is [deprecated](http://gruntjs.com/api/grunt.util#grunt.util._).
- I updated the dependencies of this project, because [the first stable version of Nunjucks has been released](https://github.com/jlongster/nunjucks/blob/master/CHANGELOG.md).
