### PR TITLE
Add support to register extensions from the grunt task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Default value: `{}`
 An object whose keys are filter names and values are functions. Each pair will
 be registered with the template environment using the [addFilter][] method.
 
+#### options.extensions
+Type: `Object`
+Default value: `{}`
+
+An object whose keys are extension names and values are `Extension`s. Each pair will
+be registered with the template environment using the [addExtension][] method.
+
 ### Other options
 
 Other options are passed directly to the [nunjucks environment object][1].
@@ -148,3 +155,4 @@ grunt.initConfig({
 [2]: http://nunjucks.jlongster.com/api#Autoescaping
 [3]: http://nunjucks.jlongster.com/api#Customizing-Variable-and-Block-Tags
 [addFilter]: http://nunjucks.jlongster.com/api#Custom-Filters
+[addExtension]: http://nunjucks.jlongster.com/api#

--- a/tasks/jinja.coffee
+++ b/tasks/jinja.coffee
@@ -30,6 +30,7 @@ module.exports = (grunt) ->
       templateDirs: [path.join process.cwd(), 'templates']
       contextRoot: path.join process.cwd(), 'template-context'
       filters: {}
+      extensions: {}
 
     loadContext = (templateName, removeExtension = true) ->
       ext = path.extname(templateName)
@@ -51,7 +52,7 @@ module.exports = (grunt) ->
     # environment.
     envOptions = {}
     for own k, v of options
-      unless k in ['templateDirs', 'contextRoot', 'filters']
+      unless k in ['templateDirs', 'contextRoot', 'filters', 'extensions']
         envOptions[k] = v
 
     env = new nunjucks.Environment loaders, envOptions
@@ -59,6 +60,10 @@ module.exports = (grunt) ->
     # Add custom filters
     for own k, v of options.filters
       env.addFilter k, v
+
+    # Add custom extensions
+    for own k, v of options.extensions
+      env.addExtension k, v
 
     # Iterate over all specified file groups.
     @files.forEach (f) ->


### PR DESCRIPTION
Simply added the `extensions` task options, like `filters`.

Added docs, fixed addExtension.
